### PR TITLE
Add unsafe pointer access to MatrixType

### DIFF
--- a/Sources/SGLMath/Complex.swift
+++ b/Sources/SGLMath/Complex.swift
@@ -34,6 +34,8 @@ extension Float {
 public struct Complex<T: FloatingPointArithmeticType>: MatrixType, ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, ExpressibleByArrayLiteral {
     public typealias Element = T
 
+    public static var elementCount: Int { 2 }
+
     public var real: T
     public var imag: T
 

--- a/Sources/SGLMath/Matrix2x2.swift
+++ b/Sources/SGLMath/Matrix2x2.swift
@@ -26,6 +26,8 @@ import simd
 public struct Matrix2x2<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 2 * 2 }
+
     private var x: Vector2<T>, y: Vector2<T>
 
     public subscript(column: Int) -> Vector2<T> {

--- a/Sources/SGLMath/Matrix2x3.swift
+++ b/Sources/SGLMath/Matrix2x3.swift
@@ -22,6 +22,8 @@
 public struct Matrix2x3<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 2 * 3 }
+
     private var x: Vector3<T>, y: Vector3<T>
 
     public subscript(column: Int) -> Vector3<T> {

--- a/Sources/SGLMath/Matrix2x4.swift
+++ b/Sources/SGLMath/Matrix2x4.swift
@@ -26,6 +26,8 @@ import simd
 public struct Matrix2x4<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 2 * 4 }
+
     private var x: Vector4<T>, y: Vector4<T>
 
     public subscript(column: Int) -> Vector4<T> {

--- a/Sources/SGLMath/Matrix3x2.swift
+++ b/Sources/SGLMath/Matrix3x2.swift
@@ -22,6 +22,8 @@
 public struct Matrix3x2<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 3 * 2 }
+
     private var x: Vector2<T>, y: Vector2<T>, z: Vector2<T>
 
     public subscript(column: Int) -> Vector2<T> {

--- a/Sources/SGLMath/Matrix3x3.swift
+++ b/Sources/SGLMath/Matrix3x3.swift
@@ -22,6 +22,8 @@
 public struct Matrix3x3<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 3 * 3 }
+
     private var x: Vector3<T>, y: Vector3<T>, z: Vector3<T>
 
     public subscript(column: Int) -> Vector3<T> {

--- a/Sources/SGLMath/Matrix3x4.swift
+++ b/Sources/SGLMath/Matrix3x4.swift
@@ -22,6 +22,8 @@
 public struct Matrix3x4<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 3 * 4 }
+
     private var x: Vector4<T>, y: Vector4<T>, z: Vector4<T>
 
     public subscript(column: Int) -> Vector4<T> {

--- a/Sources/SGLMath/Matrix4x2.swift
+++ b/Sources/SGLMath/Matrix4x2.swift
@@ -26,6 +26,8 @@ import simd
 public struct Matrix4x2<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 4 * 2 }
+
     private var x: Vector2<T>, y: Vector2<T>, z: Vector2<T>, w: Vector2<T>
 
     public subscript(column: Int) -> Vector2<T> {

--- a/Sources/SGLMath/Matrix4x3.swift
+++ b/Sources/SGLMath/Matrix4x3.swift
@@ -22,6 +22,8 @@
 public struct Matrix4x3<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 4 * 3 }
+
     private var x: Vector3<T>, y: Vector3<T>, z: Vector3<T>, w: Vector3<T>
 
     public subscript(column: Int) -> Vector3<T> {

--- a/Sources/SGLMath/Matrix4x4.swift
+++ b/Sources/SGLMath/Matrix4x4.swift
@@ -26,6 +26,8 @@ import simd
 public struct Matrix4x4<T: ArithmeticType>: MatrixType {
     public typealias Element = T
 
+    public static var elementCount: Int { 4 * 4 }
+
     private var x: Vector4<T>, y: Vector4<T>, z: Vector4<T>, w: Vector4<T>
 
     public subscript(column: Int) -> Vector4<T> {

--- a/Sources/SGLMath/Quaternion.swift
+++ b/Sources/SGLMath/Quaternion.swift
@@ -22,6 +22,8 @@
 public struct Quaternion<T: FloatingPointArithmeticType>: MatrixType, ExpressibleByArrayLiteral {
     public typealias Element = T
 
+    public static var elementCount: Int { 4 }
+
     public var x: T, y: T, z: T, w: T
 
     public var elements: [Element] {

--- a/Sources/SGLMath/Vector2.swift
+++ b/Sources/SGLMath/Vector2.swift
@@ -27,6 +27,8 @@ public struct Vector2<T: ArithmeticType>: VectorType {
     public typealias UInt32Vector = Vector2<UInt32>
     public typealias BooleanVector = Vector2b
 
+    public static var elementCount: Int { 2 }
+
     public var x: T, y: T
 
     public var r: T { get { return x } set { x = newValue } }

--- a/Sources/SGLMath/Vector2b.swift
+++ b/Sources/SGLMath/Vector2b.swift
@@ -22,6 +22,8 @@
 public struct Vector2b: BooleanVectorType {
     public typealias BooleanVector = Vector2b
 
+    public static var elementCount: Int { 2 }
+
     public var x: Bool, y: Bool
 
     public var r: Bool { get { return x } set { x = newValue } }

--- a/Sources/SGLMath/Vector3.swift
+++ b/Sources/SGLMath/Vector3.swift
@@ -27,6 +27,8 @@ public struct Vector3<T: ArithmeticType>: VectorType {
     public typealias UInt32Vector = Vector3<UInt32>
     public typealias BooleanVector = Vector3b
 
+    public static var elementCount: Int { 3 }
+
     public var x: T, y: T, z: T
 
     public var r: T { get { return x } set { x = newValue } }

--- a/Sources/SGLMath/Vector3b.swift
+++ b/Sources/SGLMath/Vector3b.swift
@@ -22,6 +22,8 @@
 public struct Vector3b: BooleanVectorType {
     public typealias BooleanVector = Vector3b
 
+    public static var elementCount: Int { 3 }
+
     public var x: Bool, y: Bool, z: Bool
 
     public var r: Bool { get { return x } set { x = newValue } }

--- a/Sources/SGLMath/Vector4.swift
+++ b/Sources/SGLMath/Vector4.swift
@@ -27,6 +27,8 @@ public struct Vector4<T: ArithmeticType>: VectorType {
     public typealias UInt32Vector = Vector4<UInt32>
     public typealias BooleanVector = Vector4b
 
+    public static var elementCount: Int { 4 }
+
     public var x: T, y: T, z: T, w: T
 
     public var r: T { get { return x } set { x = newValue } }

--- a/Sources/SGLMath/Vector4b.swift
+++ b/Sources/SGLMath/Vector4b.swift
@@ -22,6 +22,8 @@
 public struct Vector4b: BooleanVectorType {
     public typealias BooleanVector = Vector4b
 
+    public static var elementCount: Int { 4 }
+
     public var x: Bool, y: Bool, z: Bool, w: Bool
 
     public var r: Bool { get { return x } set { x = newValue } }

--- a/Tests/SGLMathTests/Matrix4x4Tests.swift
+++ b/Tests/SGLMathTests/Matrix4x4Tests.swift
@@ -119,12 +119,49 @@ class Matrix4x4Tests: XCTestCase {
         XCTAssertEqual(m0, m1)
     }
 
+    func testPointers() {
+        var m0 = mat4(
+            vec4(0, 1, 2, 3),
+            vec4(4, 5, 6, 7),
+            vec4(8, 9, 10, 11),
+            vec4(12, 13, 14, 15)
+        )
+
+        let m1 = mat4(
+            vec4(20, 21, 22, 23),
+            vec4(24, 25, 26, 27),
+            vec4(28, 29, 30, 31),
+            vec4(32, 33, 34, 35)
+        )
+
+        m0.withUnsafePointer { pointer in
+            for i in 0..<16 {
+                XCTAssertEqual(pointer[i], Float(i))
+            }
+        }
+
+        m0.withUnsafeMutablePointer { pointer in
+            for i in 0..<16 {
+                pointer[i] += 20
+            }
+        }
+
+        m0.withUnsafeBufferPointer { buffer in
+            for (i, element) in buffer.enumerated() {
+                XCTAssertEqual(element, Float(i + 20))
+            }
+        }
+
+        XCTAssertEqual(m0, m1)
+    }
+
     static var allTests = [
         ("testIdentityInits", testIdentityInits),
         ("testCommmonInits", testCommmonInits),
         ("testDivide", testDivide),
         ("testMultiplyWith2x4", testMultiplyWith2x4),
         ("testMultiplyVector", testMultiplyVector),
-        ("testMultiArray", testMultiArray)
+        ("testMultiArray", testMultiArray),
+        ("testPointers", testPointers)
     ]
 }

--- a/Tests/SGLMathTests/Vector4Tests.swift
+++ b/Tests/SGLMathTests/Vector4Tests.swift
@@ -110,6 +110,31 @@ class Vector4Tests: XCTestCase {
         XCTAssertEqual(v1/v2, v3)
     }
 
+    func testPointers() {
+        var v0 = vec4(0, 1, 2, 3)
+        let v1 = vec4(20, 21, 22, 23)
+
+        v0.withUnsafePointer { pointer in
+            for i in 0..<4 {
+                XCTAssertEqual(pointer[i], Float(i))
+            }
+        }
+
+        v0.withUnsafeMutablePointer { pointer in
+            for i in 0..<4 {
+                pointer[i] += 20
+            }
+        }
+
+        v0.withUnsafeBufferPointer { buffer in
+            for (i, element) in buffer.enumerated() {
+                XCTAssertEqual(element, Float(i + 20))
+            }
+        }
+
+        XCTAssertEqual(v0, v1)
+    }
+
     static var allTests = [
         ("testInit", testInit),
         ("testAddFloat", testAddFloat),
@@ -120,6 +145,7 @@ class Vector4Tests: XCTestCase {
         ("testMulInt", testMulInt),
         ("testMulUInt", testMulUInt),
         ("testDivFloat", testDivFloat),
-        ("testDivInt", testDivInt)
+        ("testDivInt", testDivInt),
+        ("testPointers", testPointers)
     ]
 }


### PR DESCRIPTION
This makes working with e.g. OpenGL much easier.

As an example, this allows me to write

```swift
matrix.withUnsafePointer {
    glUniformMatrix4fv(location, 1, GL_FALSE, $0)
}
```

This code is much cleaner compared to

```swift
withUnsafeBytes(of: matrix) { rawBuffer in
    let buffer = UnsafeBufferPointer(start: rawBuffer.baseAddress!.assumingMemoryBound(to: Float.self), count: 4 * 4)
    glUniformMatrix4fv(location, 1, GL_FALSE, buffer.baseAddress)
}